### PR TITLE
修复修改密码自动退出时导致的报错

### DIFF
--- a/controllers/common.go
+++ b/controllers/common.go
@@ -69,8 +69,8 @@ func (self *BaseController) auth() {
 				self.loginName = user.LoginName
 				self.userName = user.RealName
 				self.user = user
+				self.AdminAuth()
 			}
-			self.AdminAuth()
 
 			isHasAuth := strings.Contains(self.allowUrl, self.controllerName+"/"+self.actionName)
 			noAuth := "ajaxsave/ajaxdel/table/loginin/loginout/getnodes/start/show/ajaxapisave"


### PR DESCRIPTION
在后台修改密码自动跳转到退出页面时，会导致报错：
PPGo_ApiAdmin:runtime error: invalid memory address or nil pointer dereference
github.com/george518/PPGo_ApiAdmin/controllers/common.go:97
github.com/george518/PPGo_ApiAdmin/controllers/common.go:73
github.com/george518/PPGo_ApiAdmin/controllers/common.go:50

检查代码发现应该在有登录cookie且密码正确时才执行AdminAuth，请采纳。