### PR TITLE
修复ipv6地址取不全

### DIFF
--- a/controllers/common.go
+++ b/controllers/common.go
@@ -145,8 +145,9 @@ func (self *BaseController) isPost() bool {
 
 //获取用户IP地址
 func (self *BaseController) getClientIp() string {
-	s := strings.Split(self.Ctx.Request.RemoteAddr, ":")
-	return s[0]
+	s := bc.Ctx.Request.RemoteAddr
+	l := strings.LastIndex(s, ":")
+	return s[0:l]
 }
 
 // 重定向


### PR DESCRIPTION
分割字符串导致ipv6地址显示不全，修改为lastIndex